### PR TITLE
Stop thrusters on node shutdown

### DIFF
--- a/thruster_interface/scripts/thruster_interface_node.py
+++ b/thruster_interface/scripts/thruster_interface_node.py
@@ -47,6 +47,8 @@ class ThrusterInterface(object):
 
         self.output_to_zero()
 
+        rospy.on_shutdown(self.shutdown)
+
         rospy.loginfo("%s: Launching at %d Hz", rospy.get_name(), self.FREQUENCY)
 
     def output_to_zero(self):
@@ -134,7 +136,8 @@ class ThrusterInterface(object):
                 return False
         return True
 
-
+    def shutdown(self):
+        self.output_to_zero()
 
 if __name__ == '__main__':
     try:

--- a/thruster_interface/scripts/thruster_interface_node.py
+++ b/thruster_interface/scripts/thruster_interface_node.py
@@ -47,7 +47,7 @@ class ThrusterInterface(object):
 
         self.output_to_zero()
 
-        rospy.on_shutdown(self.shutdown)
+        rospy.on_shutdown(self.output_to_zero)
 
         rospy.loginfo("%s: Launching at %d Hz", rospy.get_name(), self.FREQUENCY)
 
@@ -136,8 +136,6 @@ class ThrusterInterface(object):
                 return False
         return True
 
-    def shutdown(self):
-        self.output_to_zero()
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
Sets all thrusters to neutral pulse width when the node shuts down. 
Is there anything else that needs to be done on shutdown? 
If not, this branch is ready to be merged. 