### PR TITLE
Replace spinonce() in loop with simple spin()

### DIFF
--- a/vortex_allocator/src/allocator_node.cpp
+++ b/vortex_allocator/src/allocator_node.cpp
@@ -8,7 +8,6 @@ int main(int argc, char **argv)
   ROS_INFO("Launching node.");
   ros::NodeHandle nh;
   Allocator allocator(nh);
-  while (ros::ok())
-    ros::spinOnce();
+  ros::spin();
   return 0;
 }

--- a/vortex_estimator/src/estimator_node.cpp
+++ b/vortex_estimator/src/estimator_node.cpp
@@ -6,7 +6,6 @@ int main(int argc, char **argv)
   ROS_INFO("Launching node.");
   ros::NodeHandle nh;
   SimpleEstimator estimator;
-  while (ros::ok())
-    ros::spinOnce();
+  ros::spin();
   return 0;
 }


### PR DESCRIPTION
This appears to be much more efficient. With spinonce() in a while loop, each
node (allocator and estimator) would run a core at 100 % cpu. Using simply spin(), the processes use very little cpu when idle.