### PR TITLE
Rosbridge websocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ but you can also lint manually with `catkin_make roslint`.
 The [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) C++ library
 
 `sudo apt install libeigen3-dev`
+
 ### Eigen conversions ROS package
 The [eigen_conversions](http://wiki.ros.org/eigen_conversions) ROS package
 
 `sudo apt install ros-kinetic-eigen-conversions`
+
 ### Gtest
-The gtest package in the Ubuntu repository is not precompiled, 
+The gtest package in the Ubuntu repository is not precompiled,
 so it needs to be built and put in place.
 ```
 sudo apt install libgtest-dev
@@ -59,6 +61,11 @@ sudo cp libg* /usr/lib/
 roslint is used for linting of the ROS C++/Python code.
 
 `sudo apt install ros-kinetic-roslint`
+
+### ROS-bridge-server
+Necessary for connecting the Web-based GUI to the ROV
+
+`sudo apt install ros-kinetic-rosbridge-server`
 
 ## Preferred workflow
 * Create a feature branch out of `master` for each new feature, solved issue, significant refactor, etc.

--- a/vortex/launch/manta.launch
+++ b/vortex/launch/manta.launch
@@ -1,4 +1,7 @@
 <launch>
+
+  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch"/>
+
   <env name="ROSCONSOLE_FORMAT" value="[${severity}] [${time}] [${node}]: ${message}" />
 
   <rosparam command="load" file="$(find vortex)/config/robots/manta.yaml"/>
@@ -13,6 +16,6 @@
   <node pkg="mcu_interface"      type="mcu_interface_node"         name="mcu_interface"      output="screen"/>
   <node pkg="vortex_controller"  type="node"                       name="controller"         output="screen"/>
   <node pkg="vortex_allocator"   type="node"                       name="allocator"          output="screen"/>
-  <node pkg="vortex_estimator"   type="node"                       name="estimator"          output="screen"/>    
+  <node pkg="vortex_estimator"   type="node"                       name="estimator"          output="screen"/>
 
 </launch>


### PR DESCRIPTION
Included the ros-bridge-server in the launch-script, also added it as a dependency in the README.

Related to vortexntnu/rov-gui/pull/15